### PR TITLE
v0.8.1: Handle template literals that contain identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vocabhelper",
   "displayName": "Vocab Helper",
   "description": "Helper extension for the Vocab i18n framework",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "publisher": "askoufis",
   "private": true,
   "repository": {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -218,41 +218,93 @@ suite("Vocab Helper Extension Suite", () => {
       });
     });
 
-    suite("Component containing a prop with a template string value", () => {
-      const selections = createUnquotedAndQuotedSelections(7, 17, 7, 42);
+    suite(
+      "Component containing a prop with a template string that has an identifier",
+      () => {
+        const selections = createUnquotedAndQuotedSelections(9, 27, 9, 46);
 
-      selections.map((selection) => {
-        test("should extract the translation string from the template string value, surround the hook call with curly brackets, extract the argument and add it to the translations file", async () => {
-          const testFileName = "propTemplateString.tsx";
+        selections.map((selection) => {
+          test("should extract the translation string from the template string identifier, surround the hook call with curly brackets, extract the argument and add it to the translations file", async () => {
+            const testFileName = "propTemplateString.tsx";
 
-          const expectedFileContents = dedent`
+            const expectedFileContents = dedent`
             import { useTranslations } from "@vocab/react";
             import translations from "./.vocab";
             import React from "react";
 
             const MyComponent = (props: { name: string }) => {
               const { t } = useTranslations(translations);
+
+              const { name } = props;
+
+              const foo = <div label={t("My name is name!", { name })}>{t("Already extracted")}</div>;
+
+              return (
+                <div label={\`My name is $\{props.name\}!\`}>{t("Already extracted")}</div>
+              );
+            };`;
+
+            const expectedTranslationsFileContents = dedent`
+            {
+              "My name is name!": {
+                "message": "My name is {name}!"
+              }
+            }`;
+
+            await runExtractionTest({
+              testFileName,
+              expectedFileContents,
+              expectedTranslationsFileContents,
+              selection,
+            });
+          });
+        });
+      }
+    );
+
+    suite(
+      "Component containing a prop with a template string that has a member expression",
+      () => {
+        const selections = createUnquotedAndQuotedSelections(12, 17, 12, 42);
+
+        selections.map((selection) => {
+          test("should extract the translation string from the template string member expression, surround the hook call with curly brackets, extract the argument and add it to the translations file", async () => {
+            const testFileName = "propTemplateString.tsx";
+
+            const expectedFileContents = dedent`
+            import { useTranslations } from "@vocab/react";
+            import translations from "./.vocab";
+            import React from "react";
+
+            const MyComponent = (props: { name: string }) => {
+              const { t } = useTranslations(translations);
+
+              const { name } = props;
+
+              const foo = <div label={\`My name is $\{name\}!\`}>{t("Already extracted")}</div>;
+
               return (
                 <div label={t("My name is propsName!", { propsName: props.name })}>{t("Already extracted")}</div>
               );
             };`;
 
-          const expectedTranslationsFileContents = dedent`
+            const expectedTranslationsFileContents = dedent`
             {
               "My name is propsName!": {
                 "message": "My name is {propsName}!"
               }
             }`;
 
-          await runExtractionTest({
-            testFileName,
-            expectedFileContents,
-            expectedTranslationsFileContents,
-            selection,
+            await runExtractionTest({
+              testFileName,
+              expectedFileContents,
+              expectedTranslationsFileContents,
+              selection,
+            });
           });
         });
-      });
-    });
+      }
+    );
 
     suite(
       "Component containing string literal with max key length set to 20",

--- a/src/test/suite/testFiles/propTemplateString.tsx
+++ b/src/test/suite/testFiles/propTemplateString.tsx
@@ -4,6 +4,11 @@ import React from "react";
 
 const MyComponent = (props: { name: string }) => {
   const { t } = useTranslations(translations);
+
+  const { name } = props;
+
+  const foo = <div label={`My name is ${name}!`}>{t("Already extracted")}</div>;
+
   return (
     <div label={`My name is ${props.name}!`}>{t("Already extracted")}</div>
   );

--- a/src/utils/babel/transform.test.ts
+++ b/src/utils/babel/transform.test.ts
@@ -134,7 +134,7 @@ describe("transformHighlightContainingJsx", () => {
 });
 
 describe("transformTemplateLiteralToVocabHook", () => {
-  it("should transform a string literal into the hook call", () => {
+  it("should transform a string literal with a member expression into the hook call", () => {
     const input = "`My name is ${props.name}!`";
 
     const result = transformTemplateLiteralToVocabHook(input);
@@ -142,6 +142,19 @@ describe("transformTemplateLiteralToVocabHook", () => {
       key: "My name is propsName!",
       message: "My name is {propsName}!",
       code: 't("My name is propsName!", { propsName: props.name })',
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should transform a string literal with an identifier into the hook call", () => {
+    const input = "`My name is ${name}!`";
+
+    const result = transformTemplateLiteralToVocabHook(input);
+    const expected = {
+      key: "My name is name!",
+      message: "My name is {name}!",
+      code: 't("My name is name!", { name })',
     };
 
     expect(result).toEqual(expected);

--- a/src/utils/babel/visitors.test.ts
+++ b/src/utils/babel/visitors.test.ts
@@ -37,6 +37,34 @@ describe("JSXText visitor", () => {
 
 describe("TemplateLiteral", () => {
   describe("enter visitor", () => {
+    it("should append the text and any identifiers to both the key and the message", () => {
+      const templateLiteral = t.templateLiteral(
+        [
+          t.templateElement({ raw: "My name is " }),
+          t.templateElement({ raw: "!" }, true),
+        ],
+        [t.identifier("name")]
+      );
+      const state = createInitialState();
+
+      templateLiteralEnterVisitor({ node: templateLiteral }, state);
+
+      expect(state).toEqual({
+        key: "Existing text My name is name!",
+        message: "Existing text My name is {name}!",
+        elementNameOccurrences: {},
+        translationHookProperties: [
+          t.objectProperty(
+            t.identifier("name"),
+            t.identifier("name"),
+            false,
+            true
+          ),
+        ],
+        elementNameStack: [],
+      });
+    });
+
     it("should append the text and any member expressions to both the key and the message", () => {
       const templateLiteral = t.templateLiteral(
         [

--- a/src/utils/babel/visitors.ts
+++ b/src/utils/babel/visitors.ts
@@ -64,32 +64,6 @@ export const templateLiteralExitVisitor = (
   const hookCallExpression = constructHookCallExpression(state);
 
   path.replaceWith(hookCallExpression);
-  // // Template literals alternate between quasis and expressions
-  // let index = 0;
-  // for (const quasi of templateLiteral.quasis) {
-  //   const text = quasi.value.raw;
-  //   state.key = `${state.key}${text}`;
-  //   state.message = `${state.message}${text}`;
-  //
-  //   if (quasi.tail) {
-  //     break;
-  //   }
-  //
-  //   const expression = templateLiteral.expressions[index];
-  //
-  //   if (t.isMemberExpression(expression)) {
-  //     const { keyString, objectProperty } =
-  //       memberExpressionToObjectProperty(expression);
-  //     state.key = `${state.key}${keyString}`;
-  //     state.message = `${state.message}{${keyString}}`;
-  //
-  //     state.translationHookProperties.push(objectProperty);
-  //   } else {
-  //     throw new Error(`Expected member expression, got ${expression?.type}`);
-  //   }
-  //
-  //   index += 1;
-  // }
 };
 
 export const jsxElementEnterVisitor = (


### PR DESCRIPTION
This should've been supported in #17 but I forgot to test it.